### PR TITLE
every user now has a own Folder

### DIFF
--- a/src/api/FileService.ts
+++ b/src/api/FileService.ts
@@ -3,15 +3,18 @@ import { StoreSnapshot, TLRecord } from "tldraw";
 export default class FileService {
 	private baseUrl: string;
 	private token: string;
+	private userName: string;
 
-	constructor(baseUrl: string, token: string) {
+	constructor(baseUrl: string, token: string, userName: string) {
 		this.baseUrl = baseUrl + "/api/ha_draw_persistence/upload";
 		this.token = token;
+		this.userName = userName;
 	}
 
 	async getSnapShot(fileName: string): Promise<string> {
 		const params = new URLSearchParams({
 			filename: fileName,
+			user: this.userName,
 		});
 		const response = await fetch(this.baseUrl + `?${params}`, {
 			method: "GET",
@@ -35,6 +38,7 @@ export default class FileService {
 		const form = new FormData();
 		form.append("jsondata", JSON.stringify(data));
 		form.append("filename", fileName);
+		form.append("user", this.userName);
 
 		const response = await fetch(this.baseUrl, {
 			method: "Post",

--- a/src/types/hass.ts
+++ b/src/types/hass.ts
@@ -22,6 +22,16 @@ export interface HomeAssistantState {
 			hassUrl: string;
 		};
 	};
+	user: {
+		id: string;
+		name: string;
+		is_owner: boolean;
+		is_admin: boolean;
+		credentials: {
+			auth_provider_type: string;
+			auth_provider_id: string;
+		}
+	}
 }
 
 export interface CardState {

--- a/src/utilities/canvasStore.ts
+++ b/src/utilities/canvasStore.ts
@@ -8,6 +8,7 @@ export default class CanvasStore {
 	private cardName: string; // The Name of this Card
 	private fileService: FileService; // An Instance of FileService
 	private fileName: string;
+	private userName: string;
 
 	constructor(editor: Editor, cardName: string) {
 		this.editor = editor;
@@ -19,9 +20,11 @@ export default class CanvasStore {
 		}
 		const { hass, config } = cardState;
 		this.fileName = config.value.name;
+		this.userName = hass.value.user.name;
 		this.fileService = new FileService(
 			hass.value.auth.data.hassUrl,
 			hass.value.auth.data.access_token,
+			this.userName,
 		);
 	}
 


### PR DESCRIPTION
### Persistence Update
#### Solves Issue #21 
#### Important: This Update Breaks Current Persistence – Please Back Up Files Manually
With this update, each user now has their own dedicated folder for saving drawn objects. This improvement ensures that files are organized by user and prevents users from accidentally overwriting one another's saved files.

If you're using the [Persistence Integration](https://github.com/JFK20/ha_draw_persistence), please ensure you update to the latest version to take advantage of this enhancement. Remember to back up your existing files manually before updating to avoid data loss.